### PR TITLE
remote module is remove , now can use '@electron/remote' module

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var remote = electron ? electron.remote : tryRequire('remote')
 
 var mouseConstructor = tryRequire('osx-mouse') || tryRequire('win-mouse')
 
+remote || (remote=tryRequire('@electron/remote'));
+
 var supported = !!mouseConstructor
 var noop = function () { return noop }
 


### PR DESCRIPTION
https://www.electronjs.org/zh/blog/electron-14-0#removed-remote-module